### PR TITLE
Initialize both nfft and frameLength before calling _updateCaptureDuration()

### DIFF
--- a/src/analysis/Analyser.cpp
+++ b/src/analysis/Analyser.cpp
@@ -332,9 +332,10 @@ void Analyser::loadSettings()
     settings.beginGroup("analysis");
 
     setMaximumFrequency(settings.value("maxFreq", 4700.0).value<double>());
-    setFftSize(settings.value("fftSize", 512).value<int>());
+    nfft = settings.value("fftSize", 512).value<int>();
     setLinearPredictionOrder(settings.value("lpOrder", 12).value<int>());
-    setFrameLength(std::chrono::milliseconds(settings.value("frameLength", 35).value<int>()));
+    frameLength = std::chrono::milliseconds(settings.value("frameLength", 35).value<int>());
+    _updateCaptureDuration();
     setFrameSpace(std::chrono::milliseconds(settings.value("frameSpace", 15).value<int>()));
     setWindowSpan(std::chrono::milliseconds(int(1000 * settings.value("windowSpan", 5.0).value<double>())));
     setPitchAlgorithm((PitchAlg) settings.value("pitchAlg", static_cast<int>(Wavelet)).value<int>());


### PR DESCRIPTION
`setFrameLength()` and `setFftSize()` both automatically call `_updateCaptureDuration()`, however `_updateCaptureDuration` depends on both `nfft` and `frameLength`:

```cpp
    fftSamples = nfft; //(fs * nfft) / refs;
    frameSamples = frameLength.count() / 1000.0 * fs;
```
Given this code:
```cpp
void Analyser::_updateCaptureDuration()
{
    std::lock_guard<std::mutex> lock(audioLock);

    double fs = audioCapture->getSampleRate();
    LS_INFO("sample rate " << fs);

    // Account for resampling.
    fftSamples = nfft; //(fs * nfft) / refs;
    frameSamples = frameLength.count() / 1000.0 * fs;
    LS_INFO("frameLength.count() " << frameLength.count());

    int nsamples = std::max(fftSamples, frameSamples);
    if (nsamples != this->nsamples) {
        LS_INFO("nsamples different " << nsamples << " " << fftSamples << " " << frameSamples);
        audioCapture->setCaptureDuration(nsamples);
        this->nsamples = nsamples;

        LS_INFO("Set capture duration to " << nsamples << " samples (" << (1000.0 * nsamples / fs) << " ms)");
    }
}
```
If we are unlucky, on certain runtimes like x86_64 Android we get undefined behavior for either of those variables, which leads to OOM:
```
I libSpeechAnalysis_x86.so: Loading analysis settings...
I libSpeechAnalysis_x86.so: Updating Capture Duration
I libSpeechAnalysis_x86.so: sample rate  16000
I libSpeechAnalysis_x86.so: frameLength.count()  35
I libSpeechAnalysis_x86.so: nsamples different  1869177973   1869177973   560
```
and AArch64 Android:
```
2020-04-07 23:32:06.611 [I] Set FFT size to 512 (setFftSize@../speech-analysis-android/analysis/Analyser.cpp:86)
2020-04-07 23:32:06.611 [I] sample rate 8000 (_updateCaptureDuration@../speech-analysis-android/analysis/Analyser.cpp:282)
2020-04-07 23:32:06.611 [I] frameLength.count() 6.47522e+170 (_updateCaptureDuration@../speech-analysis-android/analysis/Analyser.cpp:287)
2020-04-07 23:32:06.611 [I] nsamples different 2147483647 512 2147483647 
```